### PR TITLE
Fix randomized avatars to be persistent.

### DIFF
--- a/client/src/components/avatar/Avatar.js
+++ b/client/src/components/avatar/Avatar.js
@@ -9,6 +9,8 @@ const imgHeads = importAll(require.context('../../images/head'));
 const imgTorsos = importAll(require.context('../../images/torso'));
 const imgLegs = importAll(require.context('../../images/legs'));
 
+var IDs = {}
+
 function getRandomElement(Elements) {
 	let Index = Math.floor(Math.random() * Elements.length);
 	return Elements[Index];
@@ -16,17 +18,28 @@ function getRandomElement(Elements) {
 
 function Part(props) {
 	return (
-		<img className={props.className} src={getRandomElement(props.element).default} alt="Avatar" />
+		<img className={props.className} src={props.element.default} alt="Avatar" />
 	)
 }
 
 export default class Avatar extends react.Component {
 	render() {
+		let ID = this.props.id
+		if (!(ID in IDs)) {
+			IDs[ID] = {
+				head: getRandomElement(imgHeads),
+				torso: getRandomElement(imgTorsos),
+				legs: getRandomElement(imgLegs)
+			}
+		}
+		let head = IDs[ID].head
+		let torso = IDs[ID].torso
+		let legs = IDs[ID].legs
 		return (
 			<div>
-				<Part className="Avatar" element={imgHeads} />
-				<Part className="Avatar-Row-Child" element={imgTorsos} />
-				<Part className="Avatar-Row-Child" element={imgLegs} />
+				<Part className="Avatar" element={head} />
+				<Part className="Avatar-Row-Child" element={torso} />
+				<Part className="Avatar-Row-Child" element={legs} />
 			</div>
 		)
 	}

--- a/client/src/components/chatters/Chatters.js
+++ b/client/src/components/chatters/Chatters.js
@@ -13,7 +13,7 @@ function NamePlate(props) {
 function Chatter(props) {
 	return (
 		<div className="Chatter">
-			<Avatar />
+			<Avatar id={props.name}/>
 			<NamePlate name={props.name} />
 		</div>
 	)


### PR DESCRIPTION
Avatar images were being generated after every call to retrieve users from the server.
This commit adds a persistent object that tracks users by name with their randomly
generated avatar for a session.

Close #27.