### PR TITLE
Context menu for individual chatters with option to remove.

### DIFF
--- a/client/src/components/chatters/Chatters.js
+++ b/client/src/components/chatters/Chatters.js
@@ -1,4 +1,5 @@
 import Avatar from '../avatar/Avatar'
+import ChattersContextMenu from './ChattersContextMenu'
 import React from 'react'
 import './Chatters.css'
 
@@ -22,7 +23,14 @@ function Chatter(props) {
 export default class Chatters extends React.Component {
 	constructor(props) {
 		super(props)
-		this.state = {Items: [1, 2, 3]};
+		this.state = {
+			Items: [1, 2, 3],
+			Removed: [],
+			contextMenuTarget: null,
+			xPos: "0px",
+			yPos: "0px"
+		};
+		this.onClick = this.onClick.bind(this)
 	}
 
 	componentDidMount() {
@@ -30,10 +38,41 @@ export default class Chatters extends React.Component {
 			() => this.Request(),
 			3000
 		);
+
+		document.addEventListener("click", this.onClick);
 	}
 
 	componentWillUnmount() {
 		clearInterval(this.TimerID);
+		document.removeEventListener("click", this.onClick);
+	}
+
+	onClick(event) {
+		if (this.state.contextMenuTarget) {
+			this.setState({contextMenuTarget: null});
+		}
+	}
+
+	contextMenu(id, event) {
+		event.preventDefault();
+		this.setState({
+			contextMenuTarget: id,
+			xPos: event.pageX + "px",
+			yPos: event.pageY + "px"
+		});
+	}
+
+	onContextMenuSelection(id) {
+		let Removed = this.state.Removed;
+		if (id === "Remove") {
+			if (!Removed.includes(this.state.contextMenuTarget)) {
+				Removed.push(this.state.contextMenuTarget);
+			}
+		}
+		this.setState({
+			contextMenuTarget: null,
+			Removed: Removed
+		});
 	}
 
 	Request() {
@@ -53,13 +92,21 @@ export default class Chatters extends React.Component {
 	}
 
 	render() {
+		let Items = [];
+		for (const Item of this.state.Items) {
+			if (!this.state.Removed.includes(Item)) {
+				Items.push(<li onContextMenu={this.contextMenu.bind(this, Item)}><Chatter name={Item}/></li>);
+			}
+		}
 		return (
 		<div>
 			<h2>Chatters</h2>
 			<ul className="Chatters"> {
-				this.state.Items.map(Item => <li><Chatter name={Item}/></li>)
+				Items
 			}
-			</ul>
+			</ul> {
+				this.state.contextMenuTarget && <ChattersContextMenu onItemSelected={(id) => this.onContextMenuSelection(id)} xPos={this.state.xPos} yPos={this.state.yPos}/>
+			}
 		</div>
 		);
 	}

--- a/client/src/components/chatters/ChattersContextMenu.css
+++ b/client/src/components/chatters/ChattersContextMenu.css
@@ -1,0 +1,16 @@
+.List {
+	position: absolute;
+	list-style-type: none;
+	border: solid 1px;
+	border-radius: 2px;
+	border-width: 2px;
+	border-color: black;
+	background: solid;
+	background: #282c34;
+	margin: 0;
+	height: auto;
+	box-shadow: 0 0 20px 0 #000;
+	padding: 2px 0 2px 0;
+	width: 150px;
+	opacity: 1;
+}

--- a/client/src/components/chatters/ChattersContextMenu.js
+++ b/client/src/components/chatters/ChattersContextMenu.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import './ChattersContextMenu.css'
+
+export default class ChattersContextMenu extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			xPos: props.xPos,
+			yPos: props.yPos,
+			onItemSelected: props.onItemSelected,
+			options: [
+				"Remove"
+			]
+		}
+	}
+
+	onItemSelected(id, event) {
+		if (this.state.onItemSelected) {
+			this.state.onItemSelected(id);
+		}
+	}
+
+	render() {
+		return (
+			<div>
+				<ul className="List" style={{top: this.state.yPos, left: this.state.xPos}}> {
+					this.state.options.map(Item => <li onClick={this.onItemSelected.bind(this, Item)}>{Item}</li>)
+				}
+				</ul>
+			</div>
+		)
+	}
+}


### PR DESCRIPTION
Adds a custom context menu that allows for removing individual chatters for the
duration of the page. The context menu will only open on Chatter elements and when
removed, the ChattersList component will keep a list of removed chatters and will
only render those that have not been removed.

This is a rough first pass of this feature and is setup to allow for more options to be
added in the future.

Close #16.