### PR TITLE
Added emote list to sent object and formatting out of messages

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -67,13 +67,38 @@ client.on('message', (channel, tags, message, self) => {
 	
 	console.log(`${tags['display-name']}: ${message}`);
 	//console.log(tags);
+	let messageToSend = message;
+	let emoteOnlyMessage = false;
+	const emotesList = [];
+	if (tags.emotes) {
+		const emoteSize = `3.0`;
+		if(tags['emote-only']) {
+			emoteOnlyMessage = true;
+		}
+		Object.entries(tags.emotes).forEach(
+			([key, value]) => {
+				
+				const stringToCut = value[0].split('-')
+				const emoteString = message.substr(stringToCut[0], stringToCut[1] - stringToCut[0] + 1);
+
+				const currentEmote = {
+					emoteId: key,
+					emoteCounted: value.length,
+					emoteString,
+					emoteURL: `http://static-cdn.jtvnw.net/emoticons/v1/${key}/${emoteSize}`
+				}
+
+				emotesList.push(currentEmote);
+			})
+	}
+
 	const userStatus = {
 		userName: tags.username,
 		displayName: tags['display-name'],
 		userSubBadge: tags['badge-info'],
 		isUserSubbed: tags.subscriber,
 		userColor: tags.color,
-		userMessage: message,
+		userMessage: messageToSend,
 		userId: tags['user-id'],
 		timeStamp: tags['tmi-sent-ts']
 	}
@@ -81,10 +106,12 @@ client.on('message', (channel, tags, message, self) => {
 
 	const messageToStore = {
 		userId: tags['user-id'],
-		message: message,
+		message: messageToSend,
+		emotes: emotesList ?? null,
+		emoteOnlyMessage,
 		timeStamp: tags['tmi-sent-ts']
 	}
-
+	console.log(messageToStore);
 	userMessages.push(messageToStore);
 });
 


### PR DESCRIPTION
This is the first iteration of handling emotes in messages.  Currently, all emotes are removed from the message and now presented to the client in an array of objects.  The object contains:

- The emote ID.
- The emote count.  How many times this emote was used in the message.
- The emote URL.  Currently we are using the largest emote size, but can change between version 3, 2, or 1 (1 being the smallest).

This also does some basic formatting with some left over spaces that emotes leave.  However, there are still plenty of edge cases with handling the message before sending it off to the client.

With emotes being handled now, we can think about how emotes can be handled client-side i.e., a kobold showering emotes, or something else.  Note that currently, if there is an emote only message sent, I am handling it by injecting a 'Yip!' message, but the client should potentially handle the case of an empty message (ie not displaying a bubble with only spaces or no spaces).