### PR TITLE
Chat bubbles

### DIFF
--- a/pixi-client/public/files/chat-bubble.js
+++ b/pixi-client/public/files/chat-bubble.js
@@ -1,0 +1,85 @@
+class ChatBubble {
+	static STYLE = {fontSize: 18, align: 'center', wordWrap: true, wordWrapWidth: 400};
+	static PADDING = 30.0;
+	static MESSAGE_TIME = 3000;
+
+	constructor(parent) {
+		this.text = new PIXI.Text("", ChatBubble.STYLE);
+
+		this.graphics = new PIXI.Graphics();
+		this.graphics.alpha = 0.0;
+		this.graphics.addChild(this.text);
+
+		this.messages = [];
+		this.currentMessage = null;
+		this.messageTime = 0.0;
+
+		parent.addChild(this.graphics);
+	}
+
+	addMessage(message) {
+		if (message === null) {
+			return;
+		}
+
+		this.messages.push(message);
+	}
+
+	nextMessage() {
+		if (this.messages.length === 0) {
+			return;
+		}
+
+		this.currentMessage = this.messages.shift();
+		this.messageTime = Date.now() + ChatBubble.MESSAGE_TIME;
+
+		let textStyle = new PIXI.TextStyle(ChatBubble.STYLE);
+		let textMetrics = PIXI.TextMetrics.measureText(this.currentMessage.message, textStyle);
+		let width = textMetrics.width + ChatBubble.PADDING;
+		let height = textMetrics.height + ChatBubble.PADDING;
+
+		this.graphics.clear();
+		this.graphics.lineStyle(4, 0x424242);
+		this.graphics.beginFill(0xffffff);
+		this.graphics.drawRoundedRect(0.0, 0.0, width, height, 8);
+		this.graphics.alpha = 1.0;
+
+		this.text.text = this.currentMessage.message;
+		this.text.x = ChatBubble.PADDING * 0.5;
+		this.text.y = ChatBubble.PADDING * 0.5;
+		this.text.updateText();
+	}
+
+	update(delta, sprite) {
+		if (sprite === null) {
+			return;
+		}
+
+		if (this.messages.length > 0) {
+			if (this.currentMessage == null || this.messageTime < Date.now()) {
+				this.nextMessage();
+			}
+		} else {
+			if (this.currentMessage !== null) {
+				if (this.messageTime < Date.now()) {
+					this.currentMessage = null;
+					this.messageTime = Date.now() + ChatBubble.MESSAGE_TIME;
+				}
+			} else {
+				if (this.messageTime < Date.now()) {
+					let alpha = this.graphics.alpha;
+					this.graphics.alpha = Math.max(alpha - delta * 0.01, 0.0);
+				}
+			}
+		}
+
+		let height = this.graphics.height;
+		let textBounds = this.text.getLocalBounds();
+
+		this.graphics.x = sprite.x + sprite.width * 0.5;
+		this.graphics.y = sprite.y - sprite.height * 0.75;
+		this.graphics.width = textBounds.width;
+	}
+}
+
+export { ChatBubble };

--- a/pixi-client/public/files/chat-bubble.js
+++ b/pixi-client/public/files/chat-bubble.js
@@ -17,6 +17,10 @@ class ChatBubble {
 		parent.addChild(this.graphics);
 	}
 
+	remove(parent) {
+		parent.removeChild(this.graphics);
+	}
+
 	addMessage(message) {
 		if (message === null) {
 			return;

--- a/pixi-client/public/files/kobolds.js
+++ b/pixi-client/public/files/kobolds.js
@@ -75,7 +75,17 @@ function updateKoboldPosition(width, height, delta) {
         }
         
         koboldSprite.x += kobold.vx;
+
+        kobold.chatBubble.update(delta, koboldSprite);
     }})
 }
 
-export {addNewKobold, removeKobold, updateKoboldPosition};
+function addMessage(message) {
+    koboldList.forEach(kobold => {
+        if (kobold.userId === message.userId) {
+            kobold.chatBubble.addMessage(message);
+        }
+    });
+}
+
+export {addNewKobold, removeKobold, updateKoboldPosition, addMessage};

--- a/pixi-client/public/files/pixi-renderer.js
+++ b/pixi-client/public/files/pixi-renderer.js
@@ -1,6 +1,7 @@
 import { fetcher } from './fetcher.js';
 import { fetchstore, FS_EVENTS } from './fetch-store.js';
-import { addNewKobold, removeKobold, updateKoboldPosition } from './kobolds.js';
+import { addMessage, addNewKobold, removeKobold, updateKoboldPosition } from './kobolds.js';
+import { ChatBubble } from './chat-bubble.js';
 
 const TextureCache = PIXI.utils.TextureCache,
     Loader = PIXI.Loader.shared,
@@ -24,11 +25,17 @@ fetcher((data) => {
 		if (event == FS_EVENTS.ADD_USER) {
             const newUser = addNewKobold(data);
             app.stage.addChild(newUser.koboldSprite);
+            newUser.chatBubble = new ChatBubble(app.stage);
 		} else if (event == FS_EVENTS.REMOVE_USER) {
 			const userToRemove = removeKobold(data)
             app.stage.removeChild(userToRemove.koboldSprite);
+            userToRemove.chatBubble.remove(app.stage);
 		}
 	});
+
+    data.messages.forEach(message => {
+        addMessage(message);
+    });
 });
 
 const koboldTexture = TextureCache['files/sprites/kobold/Kobold_001.png'];


### PR DESCRIPTION
This is a first pass of chat bubble implementation. This will create chat bubble objects for each new user. All received messages are passed to the associated user and the chat bubble will properly display each message one at a time and will fade out after the final message is displayed.

This does not support emojis. Supporting emojis will take a bit of time as research is needed in order to properly display images inline with the text. This may require a bit of work to make this happen.