### PR TITLE
Added nameplates, centered sprites over names

### DIFF
--- a/pixi-client/public/files/kobolds.js
+++ b/pixi-client/public/files/kobolds.js
@@ -4,6 +4,13 @@ const WANDER_DISTANCE = 3,
     SINE_LENGTH = .2,
     HOP_DISTANCE = Math.PI * 10;
 
+const nameStyle = new PIXI.TextStyle({
+    fontFamily: 'Arial',
+    fontSize: 16,
+    fill: 'white',
+    stroke: '#FFFFFF',
+    strokeThickness: 0
+})
 
 const TextureCache = PIXI.utils.TextureCache,
     Loader = PIXI.Loader.shared,
@@ -36,6 +43,11 @@ function addNewKobold(data, yAxisLower, yAxisHigher, xAxisLower, xAxisHigher) {
 
     newKobold.koboldPlate = koboldPlate;
     newKobold.koboldSprite = koboldSprite;
+
+    const koboldName = new PIXI.Text(newKobold.name, nameStyle);
+    koboldName.position.set(0, koboldSprite.y + (koboldSprite.height / 2));
+    koboldSprite.position.set((koboldName.width / 2), 0)
+    koboldPlate.addChild(koboldName);
 
     koboldList.push(newKobold);
     return newKobold;

--- a/pixi-client/public/files/pixi-renderer.js
+++ b/pixi-client/public/files/pixi-renderer.js
@@ -3,12 +3,15 @@ import { fetchstore, FS_EVENTS } from './fetch-store.js';
 import { addMessage, addNewKobold, removeKobold, updateKoboldPosition } from './kobolds.js';
 import { ChatBubble } from './chat-bubble.js';
 
+//Debug flag for testing.
+const TEST_DEBUG = false;
+
 const TextureCache = PIXI.utils.TextureCache,
     Loader = PIXI.Loader.shared,
     Resources = PIXI.Loader.shared.resources,
     Sprite = PIXI.Sprite;
 
-const app = new PIXI.Application({ width: 360, height: 480 });
+const app = new PIXI.Application({ width: 360, height: 480, transparent: !TEST_DEBUG });
 document.body.appendChild(app.view);
 
 app.renderer.view.style.position = 'absolute';


### PR DESCRIPTION
Had added this originally to the y movement branch, but left it out when I redid it.  I've updated it to also ensure the names are now centered under the sprites.